### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -56,13 +56,22 @@ func New(ctx context.Context, opts ...Option) (*FreshdeskClient, error) {
 		return nil, err
 	}
 
-	fdURL := fmt.Sprintf(freshdeskBaseURL, freshdeskClient.domain)
-	if !isValidUrl(fdURL) {
-		return nil, fmt.Errorf("the URL: %s is not valid", fdURL)
-	}
-
-	freshdeskClient.freshdeskURL = fdURL
 	freshdeskClient.httpClient = cli
+
+	// If a custom base URL was provided, use it directly; otherwise construct from domain
+	if freshdeskClient.freshdeskURL == "" {
+		fdURL := fmt.Sprintf(freshdeskBaseURL, freshdeskClient.domain)
+		if !isValidUrl(fdURL) {
+			return nil, fmt.Errorf("the URL: %s is not valid", fdURL)
+		}
+
+		freshdeskClient.freshdeskURL = fdURL
+	} else {
+		// Custom base URL provided - validate it
+		if !isValidUrl(freshdeskClient.freshdeskURL) {
+			return nil, fmt.Errorf("the URL: %s is not valid", freshdeskClient.freshdeskURL)
+		}
+	}
 
 	return freshdeskClient, nil
 }
@@ -76,6 +85,12 @@ func WithBearerToken(apiToken string) Option {
 func WithDomain(domain string) Option {
 	return func(c *FreshdeskClient) {
 		c.domain = domain
+	}
+}
+
+func WithBaseURL(baseURL string) Option {
+	return func(c *FreshdeskClient) {
+		c.freshdeskURL = baseURL
 	}
 }
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -66,11 +66,9 @@ func New(ctx context.Context, opts ...Option) (*FreshdeskClient, error) {
 		}
 
 		freshdeskClient.freshdeskURL = fdURL
-	} else {
-		// Custom base URL provided - validate it
-		if !isValidUrl(freshdeskClient.freshdeskURL) {
-			return nil, fmt.Errorf("the URL: %s is not valid", freshdeskClient.freshdeskURL)
-		}
+	} else if !isValidUrl(freshdeskClient.freshdeskURL) {
+		// Custom base URL provided - validate it.
+		return nil, fmt.Errorf("the URL: %s is not valid", freshdeskClient.freshdeskURL)
 	}
 
 	return freshdeskClient, nil

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -6,6 +6,7 @@ import "reflect"
 type Freshdesk struct {
 	ApiKey string `mapstructure:"api-key"`
 	Domain string `mapstructure:"domain"`
+	BaseUrl string `mapstructure:"base-url"`
 }
 
 func (c *Freshdesk) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,8 +5,9 @@ import (
 )
 
 const (
-	apiKey = "api-key"
-	domain = "domain"
+	apiKey  = "api-key"
+	domain  = "domain"
+	baseURL = "base-url"
 )
 
 var (
@@ -23,8 +24,15 @@ var (
 		field.WithRequired(true),
 		field.WithDescription("Freshdesk account domain"),
 	)
+	BaseURLField = field.StringField(
+		baseURL,
+		field.WithDisplayName("Base URL"),
+		field.WithDescription("Override the Freshdesk API URL (for testing)"),
+		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
+	)
 
-	ConfigurationFields = []field.SchemaField{apiKeyField, domainField}
+	ConfigurationFields = []field.SchemaField{apiKeyField, domainField, BaseURLField}
 
 	FieldRelationships = []field.SchemaFieldRelationship{}
 )

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -97,12 +97,15 @@ func (d *Connector) Validate(ctx context.Context) (annotations.Annotations, erro
 
 // New returns a new instance of the connector.
 func New(ctx context.Context, cfg *cfg.Freshdesk, opts *cli.ConnectorOpts) (connectorbuilder.ConnectorBuilderV2, []connectorbuilder.Opt, error) {
-	freshdeskClient, err := client.New(
-		ctx,
+	clientOpts := []client.Option{
 		client.WithDomain(cfg.Domain),
 		client.WithBearerToken(cfg.ApiKey),
-	)
+	}
+	if cfg.BaseUrl != "" {
+		clientOpts = append(clientOpts, client.WithBaseURL(cfg.BaseUrl))
+	}
 
+	freshdeskClient, err := client.New(ctx, clientOpts...)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/vendor/github.com/quasilyte/go-ruleguard/dsl/dsl.go
+++ b/vendor/github.com/quasilyte/go-ruleguard/dsl/dsl.go
@@ -20,6 +20,7 @@ func (m Matcher) Import(pkgPath string) {}
 // and package name conflicts (e.g. "x/path" vs "y/path").
 func (m Matcher) ImportAs(pkgPath, localName string) {}
 
+
 // Match specifies a set of patterns that match a rule being defined.
 // Pattern matching succeeds if at least 1 pattern matches.
 //


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
pkg/client/client.go,pkg/config/conf.gen.go,pkg/config/config.go,pkg/connector/connector.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-freshdesk --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.