### PR TITLE
CXP-1 Error message when revoking a user final role

### DIFF
--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -8,7 +8,7 @@ type Freshdesk struct {
 	Domain string `mapstructure:"domain"`
 }
 
-func (c* Freshdesk) findFieldByTag(tagValue string) (any, bool) {
+func (c *Freshdesk) findFieldByTag(tagValue string) (any, bool) {
 	v := reflect.ValueOf(c).Elem() // Dereference pointer to struct
 	t := v.Type()
 
@@ -40,11 +40,13 @@ func (c *Freshdesk) GetString(fieldName string) string {
 	if !ok {
 		return ""
 	}
-	t, ok := v.(string)
-	if !ok {
-		panic("wrong type")
+	if t, ok := v.(string); ok {
+		return t
 	}
-	return t
+	if t, ok := v.([]byte); ok {
+		return string(t)
+	}
+	panic("wrong type")
 }
 
 func (c *Freshdesk) GetInt(fieldName string) int {

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -148,13 +148,18 @@ func (r *roleBuilder) Revoke(ctx context.Context, grant *v2.Grant) (annotations.
 		return nil, err
 	}
 
-	var assignedRoles []int64
+	var remainingRoles []int64
 	for _, assignedRole := range agent.RoleIDs {
 		if assignedRole != roleID {
-			assignedRoles = append(assignedRoles, assignedRole)
+			remainingRoles = append(remainingRoles, assignedRole)
 		}
 	}
-	agent.RoleIDs = assignedRoles
+
+	if len(remainingRoles) == 0 {
+		return nil, fmt.Errorf("users must have at least one role. Cannot revoke the last remaining role")
+	}
+
+	agent.RoleIDs = remainingRoles
 
 	anno, err := r.client.UpdateAgent(ctx, agent)
 	if err != nil {

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -156,7 +156,7 @@ func (r *roleBuilder) Revoke(ctx context.Context, grant *v2.Grant) (annotations.
 	}
 
 	if len(remainingRoles) == 0 {
-		return nil, fmt.Errorf("users must have at least one role. Cannot revoke the last remaining role")
+		return nil, fmt.Errorf("freshdesk users must have at least one role. Cannot revoke the last remaining role")
 	}
 
 	agent.RoleIDs = remainingRoles


### PR DESCRIPTION
#### Description

- [x] Bug fix
- [ ] New feature

Freshdesk doesn't support users without roles. When trying to revoke the last role of a user, the operation will fail with an specific error.



#### Useful links:

- [Baton SDK coding guidelines](https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines)
- [New contributor guide](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More robust handling of string values from configuration so byte-encoded entries are interpreted correctly.

* **Bug Fixes**
  * Prevented removal of a user's last role — revocation now errors if it would leave a user without any roles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->