### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -340,7 +340,6 @@ func (f *FreshdeskClient) UpdateAgent(ctx context.Context, agent *Agent) (annota
 	return anno, nil
 }
 
-
 // define error struct.
 type freshdeskAPIError struct {
 	Description string `json:"description"`

--- a/pkg/connector/groups.go
+++ b/pkg/connector/groups.go
@@ -188,9 +188,7 @@ func parseIntoGroupResource(_ context.Context, group *client.Group, parentResour
 		"group_name": group.Name,
 	}
 
-	groupTraits := []rs.GroupTraitOption{
-		rs.WithGroupProfile(profile),
-	}
+	groupTraits := []rs.GroupTraitOption{}
 
 	ret, err := rs.NewGroupResource(
 		group.Name,
@@ -198,6 +196,7 @@ func parseIntoGroupResource(_ context.Context, group *client.Group, parentResour
 		group.ID,
 		groupTraits,
 		rs.WithParentResourceID(parentResourceID),
+		rs.WithResourceProfile(profile),
 	)
 	if err != nil {
 		return nil, err
@@ -205,4 +204,3 @@ func parseIntoGroupResource(_ context.Context, group *client.Group, parentResour
 
 	return ret, nil
 }
-

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -155,7 +155,6 @@ func (r *roleBuilder) Revoke(ctx context.Context, grant *v2.Grant) (annotations.
 	return anno, nil
 }
 
-
 func newRoleBuilder(c *client.FreshdeskClient) *roleBuilder {
 	return &roleBuilder{
 		resourceType: roleResourceType,
@@ -171,11 +170,11 @@ func parseIntoRoleResource(_ context.Context, role *client.Role, _ *v2.ResourceI
 		"description": role.Description,
 	}
 
-	roleTraits := []rs.RoleTraitOption{
-		rs.WithRoleProfile(profile),
-	}
+	roleTraits := []rs.RoleTraitOption{}
 
-	ret, err := rs.NewRoleResource(role.Name, roleResourceType, role.ID, roleTraits)
+	ret, err := rs.NewRoleResource(role.Name, roleResourceType, role.ID, roleTraits,
+		rs.WithResourceProfile(profile),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -80,8 +80,6 @@ func parseIntoUserResource(agent *client.Agent, parentResourceID *v2.ResourceId)
 	}
 
 	userTraits := []rs.UserTraitOption{
-		rs.WithUserProfile(profile),
-		rs.WithStatus(userStatus),
 		rs.WithUserLogin(agent.Contact.Email),
 		rs.WithEmail(agent.Contact.Email, true),
 	}
@@ -97,6 +95,8 @@ func parseIntoUserResource(agent *client.Agent, parentResourceID *v2.ResourceId)
 		agent.ID,
 		userTraits,
 		rs.WithParentResourceID(parentResourceID),
+		rs.WithResourceProfile(profile),
+		rs.WithResourceStatus(v2.Status_ResourceStatus(userStatus), ""),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
