### PR TITLE
[CE-1177] Guard role and group grant emission behind WillSyncResourceType

### DIFF
--- a/baton_capabilities.json
+++ b/baton_capabilities.json
@@ -38,6 +38,11 @@
         "traits": [
           "TRAIT_USER"
         ],
+        "annotations": [
+          {
+            "@type": "type.googleapis.com/c1.connector.v2.SkipEntitlements"
+          }
+        ],
         "description": "The Agents are the users for Freshdesk"
       },
       "capabilities": [

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -17,12 +17,17 @@ import (
 
 type Connector struct {
 	client *client.FreshdeskClient
+	// skip*ResourceType report whether each cross-type grant target is excluded
+	// from the sync filter. Named for the skip condition so the zero value is
+	// safe: a zero-value Connector{} is used to generate the capability set.
+	skipRoleResourceType  bool
+	skipGroupResourceType bool
 }
 
 // ResourceSyncers returns a ResourceSyncer for each resource type that should be synced from the upstream service.
 func (d *Connector) ResourceSyncers(_ context.Context) []connectorbuilder.ResourceSyncerV2 {
 	return []connectorbuilder.ResourceSyncerV2{
-		newUserBuilder(d.client),
+		newUserBuilder(d.client, d.skipRoleResourceType, d.skipGroupResourceType),
 		newRoleBuilder(d.client),
 		newGroupBuilder(d.client),
 	}
@@ -110,8 +115,14 @@ func New(ctx context.Context, cfg *cfg.Freshdesk, opts *cli.ConnectorOpts) (conn
 		return nil, nil, err
 	}
 
+	// nil opts means no filter, so nothing is skipped.
+	skipRoleResourceType := opts != nil && !opts.WillSyncResourceType(RoleResourceTypeID)
+	skipGroupResourceType := opts != nil && !opts.WillSyncResourceType(GroupResourceTypeID)
+
 	cb := &Connector{
-		client: freshdeskClient,
+		client:                freshdeskClient,
+		skipRoleResourceType:  skipRoleResourceType,
+		skipGroupResourceType: skipGroupResourceType,
 	}
 
 	return cb, nil, nil

--- a/pkg/connector/integration_test.go
+++ b/pkg/connector/integration_test.go
@@ -39,7 +39,7 @@ func TestUserBuilderList(t *testing.T) {
 		t.Errorf("ERROR: Failed to create client: %v", err)
 	}
 
-	u := newUserBuilder(c)
+	u := newUserBuilder(c, false, false)
 	res, _, err := u.List(ctx, parentResourceID, attrs)
 	assert.Nil(t, err)
 	assert.NotNil(t, res)

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -4,8 +4,17 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 )
 
+// RoleResourceTypeID and GroupResourceTypeID are referenced when gating
+// cross-type grants.
+const (
+	RoleResourceTypeID  = "role"
+	GroupResourceTypeID = "group"
+)
+
 // The user resource type is for all user objects from the database.
 var (
+	// newUserBuilder clones this and adds SkipEntitlements, or
+	// SkipEntitlementsAndGrants when neither role nor group is synced.
 	userResourceType = &v2.ResourceType{
 		Id:          "user",
 		DisplayName: "User",
@@ -14,14 +23,14 @@ var (
 	}
 
 	roleResourceType = &v2.ResourceType{
-		Id:          "role",
+		Id:          RoleResourceTypeID,
 		DisplayName: "Role",
 		Description: "The Roles allow you to create special privileges and specify what an agent can see and do within your Freshdesk support portal",
 		Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_ROLE},
 	}
 
 	groupResourceType = &v2.ResourceType{
-		Id:          "group",
+		Id:          GroupResourceTypeID,
 		DisplayName: "Group",
 		Description: "The Agents can be organized into different groups. It's useful for the organization of users.",
 		Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_GROUP},

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -11,17 +11,23 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 	"github.com/conductorone/baton-sdk/pkg/types/grant"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"google.golang.org/protobuf/proto"
 )
 
 type userBuilder struct {
 	resourceType *v2.ResourceType
 	client       *client.FreshdeskClient
+	// skip*ResourceType report whether each cross-type grant target is excluded
+	// from the sync filter. Named for the skip condition so the zero value is
+	// safe: a zero-value Connector{} is used to generate the capability set.
+	skipRoleResourceType  bool
+	skipGroupResourceType bool
 }
 
 var _ connectorbuilder.AccountManagerV2 = &userBuilder{}
 
 func (u *userBuilder) ResourceType(_ context.Context) *v2.ResourceType {
-	return userResourceType
+	return u.resourceType
 }
 
 // List returns all the users from the database as resource objects.
@@ -119,20 +125,24 @@ func (u *userBuilder) Grants(ctx context.Context, resource *v2.Resource, _ rs.Sy
 
 	var rv []*v2.Grant
 
-	for _, roleID := range agentDetail.RoleIDs {
-		roleGrant := grant.NewGrant(&v2.Resource{Id: &v2.ResourceId{
-			ResourceType: roleResourceType.Id,
-			Resource:     strconv.FormatInt(roleID, 10),
-		}}, "assigned", resource.Id)
-		rv = append(rv, roleGrant)
+	if !u.skipRoleResourceType {
+		for _, roleID := range agentDetail.RoleIDs {
+			roleGrant := grant.NewGrant(&v2.Resource{Id: &v2.ResourceId{
+				ResourceType: roleResourceType.Id,
+				Resource:     strconv.FormatInt(roleID, 10),
+			}}, "assigned", resource.Id)
+			rv = append(rv, roleGrant)
+		}
 	}
 
-	for _, groupID := range agentDetail.GroupIDs {
-		groupGrant := grant.NewGrant(&v2.Resource{Id: &v2.ResourceId{
-			ResourceType: groupResourceType.Id,
-			Resource:     strconv.FormatInt(groupID, 10),
-		}}, "member", resource.Id)
-		rv = append(rv, groupGrant)
+	if !u.skipGroupResourceType {
+		for _, groupID := range agentDetail.GroupIDs {
+			groupGrant := grant.NewGrant(&v2.Resource{Id: &v2.ResourceId{
+				ResourceType: groupResourceType.Id,
+				Resource:     strconv.FormatInt(groupID, 10),
+			}}, "member", resource.Id)
+			rv = append(rv, groupGrant)
+		}
 	}
 
 	return rv, &rs.SyncOpResults{}, nil
@@ -235,9 +245,24 @@ func (u *userBuilder) Delete(ctx context.Context, resourceId *v2.ResourceId) (an
 	return profile, nil
 }
 
-func newUserBuilder(c *client.FreshdeskClient) *userBuilder {
+// newUserBuilder returns the user syncer. Users have no entitlements of their
+// own, and their only grants are cross-type role and group grants, so when BOTH
+// are excluded the grants pass is skipped too. With either one still synced the
+// per-target guards in Grants do the filtering.
+func newUserBuilder(c *client.FreshdeskClient, skipRoleResourceType, skipGroupResourceType bool) *userBuilder {
+	rt := proto.Clone(userResourceType).(*v2.ResourceType)
+	annos := annotations.Annotations(rt.GetAnnotations())
+	if skipRoleResourceType && skipGroupResourceType {
+		annos.Update(&v2.SkipEntitlementsAndGrants{})
+	} else {
+		annos.Update(&v2.SkipEntitlements{})
+	}
+	rt.Annotations = annos
+
 	return &userBuilder{
-		resourceType: userResourceType,
-		client:       c,
+		resourceType:          rt,
+		client:                c,
+		skipRoleResourceType:  skipRoleResourceType,
+		skipGroupResourceType: skipGroupResourceType,
 	}
 }

--- a/pkg/connector/users_guard_test.go
+++ b/pkg/connector/users_guard_test.go
@@ -1,0 +1,71 @@
+package connector
+
+import (
+	"context"
+	"testing"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"google.golang.org/protobuf/proto"
+)
+
+func hasAnno(rt *v2.ResourceType, msg proto.Message) bool {
+	for _, a := range rt.GetAnnotations() {
+		if a.MessageIs(msg) {
+			return true
+		}
+	}
+	return false
+}
+
+// The user type's only grants are cross-type role and group grants. Escalate to
+// SkipEntitlementsAndGrants only when BOTH targets are excluded — with either
+// one still synced the grants pass must run so that target's grants are emitted.
+func TestUserResourceType_SkipAnnotation(t *testing.T) {
+	cases := []struct {
+		name                string
+		skipRole, skipGroup bool
+		wantSkipBoth        bool
+	}{
+		{"both synced", false, false, false},
+		{"role filtered", true, false, false},
+		{"group filtered", false, true, false},
+		{"both filtered", true, true, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := newUserBuilder(nil, tc.skipRole, tc.skipGroup).ResourceType(context.Background())
+			if hasAnno(rt, &v2.SkipEntitlementsAndGrants{}) != tc.wantSkipBoth {
+				t.Fatalf("SkipEntitlementsAndGrants = %v, want %v", !tc.wantSkipBoth, tc.wantSkipBoth)
+			}
+			if hasAnno(rt, &v2.SkipEntitlements{}) == tc.wantSkipBoth {
+				t.Fatalf("SkipEntitlements presence wrong for %s", tc.name)
+			}
+		})
+	}
+
+	// Both branches annotate, so a dropped proto.Clone would leak either one
+	// onto the shared package-level value.
+	if hasAnno(userResourceType, &v2.SkipEntitlementsAndGrants{}) || hasAnno(userResourceType, &v2.SkipEntitlements{}) {
+		t.Fatal("package-level userResourceType was mutated")
+	}
+}
+
+// A zero-value Connector{} is used to generate the capability set, bypassing
+// New; it must report the unfiltered capabilities.
+func TestZeroValueConnector_DoesNotSkipGrants(t *testing.T) {
+	var found bool
+	for _, s := range (&Connector{}).ResourceSyncers(context.Background()) {
+		rt := s.ResourceType(context.Background())
+		if rt.GetId() != userResourceType.Id {
+			continue
+		}
+		found = true
+		if hasAnno(rt, &v2.SkipEntitlementsAndGrants{}) {
+			t.Fatal("zero-value Connector advertised SkipEntitlementsAndGrants")
+		}
+	}
+	if !found {
+		t.Fatal("user syncer missing from ResourceSyncers; nothing was asserted")
+	}
+}


### PR DESCRIPTION
Closes CE-1177.

`userBuilder.Grants` emits only cross-type grants — role assignments and group memberships, both read from the agent detail. Each target is now gated independently on the sync filter, so a grant is never emitted against a resource type that was not synced.

### Annotation shape

Users have no entitlements of their own, so the user type always carries `SkipEntitlements`. It escalates to `SkipEntitlementsAndGrants` **only when both `role` and `group` are excluded** — the only case where the grants pass has nothing left to emit. With either target still synced the pass must run, and the per-target guards inside `Grants` do the filtering.

That escalation also avoids the per-user `GetAgentDetail` call in the both-excluded case, since the SDK skips the pass before `Grants` is invoked.

### Also in this PR

- `pkg/connector/integration_test.go` — updated the `newUserBuilder` call site for the new signature.
- `baton_capabilities.json` — regenerated for the new annotation. This repo has **no** metadata-generation workflow and no `validate_metadata` check, so the committed file is not refreshed automatically and would otherwise have drifted.

### Testing

- `TestUserResourceType_SkipAnnotation` table-tests all four filter combinations and asserts the package-level `userResourceType` is never mutated (both annotation types).
- `TestZeroValueConnector_DoesNotSkipGrants` guards the capabilities factory path, and fails if the user syncer is ever dropped rather than passing vacuously.
- `go build`, `go vet`, `go test ./...` pass; `golangci-lint` matches the 4 pre-existing `staticcheck` issues on `main` with none added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)